### PR TITLE
auto expand partial keys

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ group :test do
   gem "capybara"
   gem "evergreen"
   gem "capybara-webkit"
+  gem 'selenium-webdriver'
 end
 
 group :assets do

--- a/i18n_viz.gemspec
+++ b/i18n_viz.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.email       = ["jakobhilden@gmail.com"]
   s.homepage    = "https://github.com/jhilden/i18n_viz"
   s.summary     = "Visualize i18n strings alongside their keys within the frontend of internationalized Rails/Ruby web applications."
-  #s.description = "TODO: Description of I18nViz."
+  s.description = "I18nViz will help everyone to figure out where which i18n key is being used by adding a little overlay which can even link to any existing translation platform."
 
   s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.md"]
   s.test_files = Dir["test/**/*"]

--- a/lib/i18n_viz/view_helpers.rb
+++ b/lib/i18n_viz/view_helpers.rb
@@ -5,9 +5,9 @@ module I18nViz
       if display_i18n_viz? && options[:i18n_viz] != false
         # TODO: ActionController::Base.perform_caching = false  if ActionController::Base.perform_caching == true
         if !options[:scope].blank? 
-          "#{super(key, options)}--#{options[:scope].to_s}.#{key}--"
+          "#{super(key, options)}--#{options[:scope].to_s}.#{scope_key_by_partial(key)}--"
         else
-          "#{super(key, options)}--#{key}--"
+          "#{super(key, options)}--#{scope_key_by_partial(key)}--"
         end
       else
         super(key, options)

--- a/test/i18n_viz_test.rb
+++ b/test/i18n_viz_test.rb
@@ -47,7 +47,9 @@ class I18nVizJavascriptIntegrationTest < ActionDispatch::IntegrationTest
 
     assert !page.has_content?("--hello--") # should be removed by js
     assert page.has_css?(".i18n-viz")
-    save_and_open_page
+
+    first('.i18n-viz').hover
+
     assert page.has_css?("#i18n_viz_tooltip")
   end
 end


### PR DESCRIPTION
as you can use partial i18n keys that start with a `.` this change
will allow us to render the complete key into the view, which
makes it easier to later find the key in an external application
as it would be with just the partial one, because that might be
ambiguous. 